### PR TITLE
Fix tree not rendering when no metadata specified

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 
@@ -22,4 +22,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/peterk87/shiptv',
-    version='0.4.0',
+    version='0.4.1',
     zip_safe=False,
 )

--- a/shiptv/__init__.py
+++ b/shiptv/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Peter Kruczkiewicz"""
 __email__ = 'peter.kruczkiewicz@gmail.com'
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/shiptv/cli.py
+++ b/shiptv/cli.py
@@ -3,6 +3,7 @@
 """Console script for shiptv."""
 import logging
 from pathlib import Path
+from sys import version_info
 from typing import Optional
 
 from Bio import Phylo
@@ -10,89 +11,154 @@ import pandas as pd
 import typer
 from rich.logging import RichHandler
 
-from shiptv.shiptv import genbank_metadata, add_user_metadata, parse_tree, \
-    write_html_tree, parse_leaf_list, prune_tree, reorder_metadata_fields, \
-    get_metadata_fields, add_user_samples_field, try_fix_serotype_metadata, \
-    try_fix_country_metadata, \
-    try_fix_collection_date_metadata, try_fix_host_metadata, collapse_branches, subset_metadata_table
+from shiptv.shiptv import (
+    genbank_metadata,
+    add_user_metadata,
+    parse_tree,
+    write_html_tree,
+    parse_leaf_list,
+    prune_tree,
+    reorder_metadata_fields,
+    get_metadata_fields,
+    add_user_samples_field,
+    try_fix_serotype_metadata,
+    try_fix_country_metadata,
+    try_fix_collection_date_metadata,
+    try_fix_host_metadata,
+    collapse_branches,
+    subset_metadata_table,
+)
+from shiptv import __version__
 
 app = typer.Typer()
 
 
-@app.command()
-def main(newick: Path = typer.Option(..., '-n', '--newick', help='Phylogenetic tree Newick file'),
-         output_html: Path = typer.Option(..., '-o', '--output-html', help='Output HTML tree path'),
-         output_newick: Optional[Path] = typer.Option(None, '-N', '--output-newick', help='Output Newick file'),
-         ref_genomes_genbank: Optional[Path] = typer.Option(None, '-r', '--ref-genomes-genbank',
-                                                            help='Reference genome sequences Genbank file'),
-         output_metadata_table: Optional[Path] = typer.Option(None, '-m', '--output-metadata-table',
-                                                              help='Output metadata table path'),
-         leaflist: Path = typer.Option(None, help='Optional leaf names to select from phylogenetic tree '
-                                                  'for pruned tree visualization. One leaf name per line.'),
-         genbank_metadata_fields: Path = typer.Option(None, help='Optional fields to extract from Genbank source '
-                                                                 'metadata. One field per line.'),
-         user_sample_metadata: Path = typer.Option(None, '-M', '--metadata',
-                                                   help='Optional tab-delimited metadata for user samples to join with'
-                                                        ' metadata derived from reference genome sequences Genbank '
-                                                        'file. Sample IDs must be in the first column.'),
-         metadata_fields_in_order: Path = typer.Option(None,
-                                                       help='Optional list of fields in order to output in metadata '
-                                                            'table and HTML tree visualization. One field per line.'),
-         fix_metadata: bool = typer.Option(True, help='Try to automatically fix metadata from reference Genbank file.'),
-         collapse_support: float = typer.Option(-1.0, '-C', '--collapse-support',
-                                                help='Collapse internal branches below specified bootstrap '
-                                                     'support value (default -1 for no collapsing)'),
-         highlight_user_samples: bool = typer.Option(False, help='Highlight user samples with metadata field in tree.'),
-         outgroup: str = typer.Option(None, help='Tree outgroup taxa'),
-         midpoint_root: bool = typer.Option(False, help='Set midpoint root'),
-         verbose: bool = typer.Option(False, help='Verbose logs')):
-    """Create HTML tree visualization with metadata.
+def version_callback(value: bool):
+    if value:
+        typer.echo(f"shiptv version {__version__}")
+        raise typer.Exit()
 
-    The metadata for reference genomes can be extracted from the specified
-    Genbank file.
 
-    Any leaf names that are present in the tree but not present in the Genbank
-    file are assumed to be user samples and are flagged as such in the
-    metadata table as "user_sample"="Yes".
+@app.command(
+    epilog=f"shiptv version {__version__}; Python {version_info.major}.{version_info.minor}.{version_info.micro}"
+)
+def main(
+    newick: Path = typer.Option(
+        ..., "-n", "--newick", help="Phylogenetic tree Newick file"
+    ),
+    output_html: Path = typer.Option(
+        "shiptv-tree.html", "-o", "--output-html", help="Output HTML tree path"
+    ),
+    output_newick: Optional[Path] = typer.Option(
+        None, "-N", "--output-newick", help="Output Newick file"
+    ),
+    ref_genomes_genbank: Optional[Path] = typer.Option(
+        None,
+        "-r",
+        "--ref-genomes-genbank",
+        help="Reference genome sequences Genbank file",
+    ),
+    output_metadata_table: Optional[Path] = typer.Option(
+        None, "-M", "--output-metadata-table", help="Output metadata table path"
+    ),
+    leaflist: Path = typer.Option(
+        None,
+        help="Optional leaf names to select from phylogenetic tree "
+        "for pruned tree visualization. One leaf name per line.",
+    ),
+    genbank_metadata_fields: Path = typer.Option(
+        None,
+        help="Optional fields to extract from Genbank source "
+        "metadata. One field per line.",
+    ),
+    user_sample_metadata: Path = typer.Option(
+        None,
+        "-m",
+        "--metadata",
+        help="Optional tab-delimited metadata for user samples to join with"
+        " metadata derived from reference genome sequences Genbank "
+        "file. Sample IDs must be in the first column.",
+    ),
+    metadata_fields_in_order: Path = typer.Option(
+        None,
+        help="Optional list of fields in order to output in metadata "
+        "table and HTML tree visualization. One field per line.",
+    ),
+    fix_metadata: bool = typer.Option(
+        True, help="Try to automatically fix metadata from reference Genbank file."
+    ),
+    collapse_support: float = typer.Option(
+        -1.0,
+        "-C",
+        "--collapse-support",
+        help="Collapse internal branches below specified bootstrap "
+        "support value (default -1 for no collapsing)",
+    ),
+    highlight_user_samples: bool = typer.Option(
+        False, help="Highlight user samples with metadata field in tree."
+    ),
+    outgroup: str = typer.Option(None, help="Tree outgroup taxa"),
+    midpoint_root: bool = typer.Option(False, help="Set midpoint root"),
+    verbose: bool = typer.Option(False, help="Verbose logs"),
+    version: Optional[bool] = typer.Option(
+        None,
+        callback=version_callback,
+        help=f'Print "shiptv version {__version__}" and exit',
+    ),
+):
+    """shiptv - create an HTML tree visualization with optional metadata highlighting
+
+    Typical usage:
+
+    $ shiptv --newick tree.nwk --metadata tree-metadata.tsv --output-html tree.html
+
+    Note: The metadata for reference genomes can be extracted from the specified Genbank file.
     """
     from rich.traceback import install
+
     install(show_locals=True)
 
-    logging.basicConfig(format='%(message)s',
-                        datefmt='[%Y-%m-%d %X]',
-                        level=logging.INFO if not verbose else logging.DEBUG,
-                        handlers=[RichHandler(rich_tracebacks=True,
-                                              tracebacks_show_locals=True)])
+    logging.basicConfig(
+        format="%(message)s",
+        datefmt="[%Y-%m-%d %X]",
+        level=logging.INFO if not verbose else logging.DEBUG,
+        handlers=[RichHandler(rich_tracebacks=True, tracebacks_show_locals=True)],
+    )
 
     tree = parse_tree(newick, outgroup=outgroup, midpoint_root=midpoint_root)
     leaf_names = [x.name for x in tree.get_terminals()]
     if collapse_support != -1:
-        logging.info(f'Collapsing internal branches with support values less '
-                     f'than {collapse_support}')
+        logging.info(
+            f"Collapsing internal branches with support values less "
+            f"than {collapse_support}"
+        )
         collapse_branches(tree, collapse_support)
     if output_newick:
-        Phylo.write([tree], output_newick, 'newick')
+        Phylo.write([tree], output_newick, "newick")
     if ref_genomes_genbank:
         df_metadata = genbank_metadata(ref_genomes_genbank)
-        logging.info(f'Parsed metadata from "{ref_genomes_genbank}" with columns: {list(df_metadata.columns)}')
+        logging.info(
+            f'Parsed metadata from "{ref_genomes_genbank}" with columns: {list(df_metadata.columns)}'
+        )
         if fix_metadata:
             try_fix_serotype_metadata(df_metadata)
             try_fix_country_metadata(df_metadata)
             try_fix_collection_date_metadata(df_metadata)
             try_fix_host_metadata(df_metadata)
         else:
-            logging.warning('Not fixing any genome metadata.')
+            logging.warning("Not fixing any genome metadata.")
 
         metadata_fields = get_metadata_fields(genbank_metadata_fields)
         # only use columns present in the reference genome metadata
-        metadata_fields = [x for x in metadata_fields if
-                           x in list(df_metadata.columns)]
-        logging.info(f'Metadata table fields: {metadata_fields}')
+        metadata_fields = [x for x in metadata_fields if x in list(df_metadata.columns)]
+        logging.info(f"Metadata table fields: {metadata_fields}")
 
     else:
         df_metadata = pd.DataFrame(index=leaf_names)
-        logging.info(f'df_metadata index dtype = {df_metadata.index.dtype} '
-                     f'| {df_metadata.index.values[0]} is {type(df_metadata.index.values[0])}')
+        logging.info(
+            f"df_metadata index dtype = {df_metadata.index.dtype} "
+            f"| {df_metadata.index.values[0]} is {type(df_metadata.index.values[0])}"
+        )
         metadata_fields = []
 
     if highlight_user_samples:
@@ -105,11 +171,13 @@ def main(newick: Path = typer.Option(..., '-n', '--newick', help='Phylogenetic t
         add_user_metadata(df_metadata, user_sample_metadata)
     df_metadata = reorder_metadata_fields(df_metadata, metadata_fields_in_order)
     if output_metadata_table:
-        df_metadata.to_csv(output_metadata_table, sep='\t')
-        logging.info(f'Wrote tab-delimited genome metadata table with '
-                     f'{df_metadata.shape[0]} rows and '
-                     f'{df_metadata.shape[1]} columns to '
-                     f'"{output_metadata_table}"')
+        df_metadata.to_csv(output_metadata_table, sep="\t")
+        logging.info(
+            f"Wrote tab-delimited genome metadata table with "
+            f"{df_metadata.shape[0]} rows and "
+            f"{df_metadata.shape[1]} columns to "
+            f'"{output_metadata_table}"'
+        )
     write_html_tree(df_metadata, output_html, tree)
     logging.info(f'Wrote HTML tree to "{output_html}"')
 

--- a/shiptv/shiptv.py
+++ b/shiptv/shiptv.py
@@ -24,7 +24,7 @@ resources = {
     'phylocanvas_js': 'https://unpkg.com/phylocanvas@2.8.1/dist/phylocanvas.js',
     'polyfill_js': 'https://unpkg.com/phylocanvas@2.8.1/polyfill.js',
     'chroma_js': 'https://unpkg.com/chroma-js@2.0.2/chroma.js',
-    'lodash_js': 'https://unpkg.com/lodash@4.17.11/lodash.min.js',
+    'lodash_js': 'https://unpkg.com/lodash@4.17.15/lodash.min.js',
     'ag_grid_js': 'https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js',
     'ag_grid_css': 'https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css',
     'ag_grid_theme_css': 'https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css',

--- a/shiptv/tmpl/phylocanvas.html
+++ b/shiptv/tmpl/phylocanvas.html
@@ -4,325 +4,406 @@
 <html>
 <head>
   <style>
-    body {
-      margin: 0.625em auto;
-      /*max-width: 60em;*/
-    }
-    #tree-plot {
-      width: 100%;
-      height: 40em;
-    }
+      body {
+          margin: 0.625em auto;
+          /*max-width: 60em;*/
+      }
 
-    .phylocanvas-context-menu,
-    .phylocanvas-context-menu ul {
-      list-style: outside none none;
-      margin: 0;
-    }
+      #tree-plot {
+          width: 100%;
+          height: 40em;
+      }
 
-    .phylocanvas-context-menu {
-      background: #fff;
-      border-radius: 2px;
-      box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
-      letter-spacing: 0px;
-      list-style: outside none none;
-      min-width: 124px;
-      padding: 8px 0;
-    }
+      .phylocanvas-context-menu,
+      .phylocanvas-context-menu ul {
+          list-style: outside none none;
+          margin: 0;
+      }
 
-    .phylocanvas-context-menu ul {
-      padding: 0;
-    }
+      .phylocanvas-context-menu {
+          background: #fff;
+          border-radius: 2px;
+          box-shadow: 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+          letter-spacing: 0px;
+          list-style: outside none none;
+          min-width: 124px;
+          padding: 8px 0;
+      }
 
-    .phylocanvas-context-menu ul + ul {
-      border-top: 1px solid #e0e0e0;
-      margin-top: 8px;
-      padding-top: 8px;
-    }
+      .phylocanvas-context-menu ul {
+          padding: 0;
+      }
 
-    .phylocanvas-context-menu li {
-      padding: 0 16px;
-      outline-color: #bdbdbd;
-      height: 40px;
-      line-height: 40px;
-      text-decoration: none;
-      background-color: transparent;
-      cursor: pointer;
-      font-size: 13px;
-      font-family: Helvetica, Arial, sans-serif;
-    }
+      .phylocanvas-context-menu ul + ul {
+          border-top: 1px solid #e0e0e0;
+          margin-top: 8px;
+          padding-top: 8px;
+      }
 
-    .phylocanvas-context-menu li:hover,
-    .phylocanvas-context-menu li:focus {
-      background-color: #eee;
-    }
+      .phylocanvas-context-menu li {
+          padding: 0 16px;
+          outline-color: #bdbdbd;
+          height: 40px;
+          line-height: 40px;
+          text-decoration: none;
+          background-color: transparent;
+          cursor: pointer;
+          font-size: 13px;
+          font-family: Helvetica, Arial, sans-serif;
+      }
 
-    .phylocanvas-context-menu a {
-      display: block;
-      margin: 0 -16px;
-      padding: 0 16px;
-    }
+      .phylocanvas-context-menu li:hover,
+      .phylocanvas-context-menu li:focus {
+          background-color: #eee;
+      }
 
-    .phylocanvas-context-menu li,
-    .phylocanvas-context-menu a {
-      color: rgba(0, 0, 0, 0.87);
-      text-decoration: none;
-      white-space: nowrap;
-    }
-    .phylocanvas-history {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      box-sizing: border-box;
-      width: 240px;
-      background: #fff;
-      transform: translateX(-240px);
-      transform-style: preserve-3d;
-      will-change: transform;
-      transition-duration: .2s;
-      transition-timing-function: cubic-bezier(.4,0,.2,1);
-      transition-property: transform;
-      border: 1px solid #e7e7e7;
-      border-left: none;
-    }
+      .phylocanvas-context-menu a {
+          display: block;
+          margin: 0 -16px;
+          padding: 0 16px;
+      }
 
-    .phylocanvas-history--open {
-      transform: translateX(0);
-      box-shadow: 0 2px 2px 0 rgba(0,0,0,.14),0 3px 1px -2px rgba(0,0,0,.2),0 1px 5px 0 rgba(0,0,0,.12);
-    }
+      .phylocanvas-context-menu li,
+      .phylocanvas-context-menu a {
+          color: rgba(0, 0, 0, 0.87);
+          text-decoration: none;
+          white-space: nowrap;
+      }
 
-    .phylocanvas-history-button {
-      border: none;
-      height: 24px;
-      line-height: 24px;
-      text-align: center;
-      margin: auto;
-      min-width: 56px;
-      width: 56px;
-      padding: 0;
-      overflow: hidden;
-      background: #3c7383;
-      color: #fff;
-      box-shadow: 0 1px 1.5px 0 rgba(0,0,0,.12),0 1px 1px 0 rgba(0,0,0,.24);
-      position: relative;
-      line-height: normal;
-      position: absolute;
-      bottom: 16px;
-      right: -57px;
-      z-index: 1;
-      outline: none;
-      cursor: pointer;
-      border-radius: 0 0 2px 2px;
-      font-size: 13px;
-      font-family: Helvetica, Arial, sans-serif;
-      transform: rotate(-90deg);
-      transform-origin: top left;
-    }
+      .phylocanvas-history {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          box-sizing: border-box;
+          width: 240px;
+          background: #fff;
+          transform: translateX(-240px);
+          transform-style: preserve-3d;
+          will-change: transform;
+          transition-duration: .2s;
+          transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+          transition-property: transform;
+          border: 1px solid #e7e7e7;
+          border-left: none;
+      }
 
-    .phylocanvas-history-snapshots {
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      margin: 0;
-      padding: 0;
-      overflow-x: hidden;
-      overflow-y: scroll;
-    }
+      .phylocanvas-history--open {
+          transform: translateX(0);
+          box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .2), 0 1px 5px 0 rgba(0, 0, 0, .12);
+      }
 
-    .phylocanvas-history-snapshot {
-      list-style: none;
-      border-bottom: 1px solid #e7e7e7;
-      cursor: pointer;
-      box-sizing: border-box;
-      display: block;
-      position: relative;
-      height: 128px;
-    }
+      .phylocanvas-history-button {
+          border: none;
+          height: 24px;
+          line-height: 24px;
+          text-align: center;
+          margin: auto;
+          min-width: 56px;
+          width: 56px;
+          padding: 0;
+          overflow: hidden;
+          background: #3c7383;
+          color: #fff;
+          box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, .12), 0 1px 1px 0 rgba(0, 0, 0, .24);
+          position: relative;
+          line-height: normal;
+          position: absolute;
+          bottom: 16px;
+          right: -57px;
+          z-index: 1;
+          outline: none;
+          cursor: pointer;
+          border-radius: 0 0 2px 2px;
+          font-size: 13px;
+          font-family: Helvetica, Arial, sans-serif;
+          transform: rotate(-90deg);
+          transform-origin: top left;
+      }
 
-    .phylocanvas-history-snapshot::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      bottom: 0;
-      right: 0;
-      width: 4px;
-      background-color: transparent;
-      transition: background-color .2s cubic-bezier(.4,0,.2,1);
-    }
+      .phylocanvas-history-snapshots {
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          margin: 0;
+          padding: 0;
+          overflow-x: hidden;
+          overflow-y: scroll;
+      }
 
-    .phylocanvas-history-snapshot:hover::after,
-    .phylocanvas-history-snapshot--selected::after {
-      background-color: #3c7383;
-    }
+      .phylocanvas-history-snapshot {
+          list-style: none;
+          border-bottom: 1px solid #e7e7e7;
+          cursor: pointer;
+          box-sizing: border-box;
+          display: block;
+          position: relative;
+          height: 128px;
+      }
 
-    .phylocanvas-history-snapshot > img {
-      width: 100%;
-      height: 128px;
-      object-fit: contain;
-    }
+      .phylocanvas-history-snapshot::after {
+          content: "";
+          position: absolute;
+          top: 0;
+          bottom: 0;
+          right: 0;
+          width: 4px;
+          background-color: transparent;
+          transition: background-color .2s cubic-bezier(.4, 0, .2, 1);
+      }
+
+      .phylocanvas-history-snapshot:hover::after,
+      .phylocanvas-history-snapshot--selected::after {
+          background-color: #3c7383;
+      }
+
+      .phylocanvas-history-snapshot > img {
+          width: 100%;
+          height: 128px;
+          object-fit: contain;
+      }
   </style>
-  <style>{{ bootstrap_css }}</style>
-  <script>{{ jquery_js }}</script>
-  <script>{{ popper_js }}</script>
-  <script>{{ bootstrap_js }}</script>
-  <script>{{ phylocanvas_js }}</script>
-  <script>{{ polyfill_js }}</script>
-  <script>{{ chroma_js }}</script>
-  <script>{{ lodash_js }}</script>
-  <script>{{ ag_grid_js }}</script>
-  <style>{{ ag_grid_css }}</style>
-  <style>{{ ag_grid_theme_css }}</style>
-  <style>{{ select2_css }}</style>
-  <script>{{ select2_js }}</script>
+  <style>{
+  {
+      bootstrap_css
+  }
+  }</style>
+  <script>{
+    {
+      jquery_js
+    }
+  }</script>
+  <script>{
+    {
+      popper_js
+    }
+  }</script>
+  <script>{
+    {
+      bootstrap_js
+    }
+  }</script>
+  <script>{
+    {
+      phylocanvas_js
+    }
+  }</script>
+  <script>{
+    {
+      polyfill_js
+    }
+  }</script>
+  <script>{
+    {
+      chroma_js
+    }
+  }</script>
+  <script>{
+    {
+      lodash_js
+    }
+  }</script>
+  <script>{
+    {
+      ag_grid_js
+    }
+  }</script>
+  <style>{
+  {
+      ag_grid_css
+  }
+  }</style>
+  <style>{
+  {
+      ag_grid_theme_css
+  }
+  }</style>
+  <style>{
+  {
+      select2_css
+  }
+  }</style>
+  <script>{
+    {
+      select2_js
+    }
+  }</script>
 </head>
 <body>
-  <nav id="nav">
-    <div class="nav nav-tabs" id="nav-tab" role="tablist">
-      <a class="nav-item nav-link active"
-         id="tree-tab-link"
-         href="#tree-tab"
-         data-toggle="tab"
-         role="tab"
-         aria-controls="tree-tab"
-         aria-selected="true">
-        Tree <span class="sr-only">(current)</span>
-      </a>
-      <a class="nav-item nav-link"
-           id="table-tab-link"
-           href="#table-tab"
-           data-toggle="tab"
-           role="tab"
-           aria-controls="table-tab"
-           aria-selected="true">
-         Table
-       </a>
-    </div>
-  </nav>
-  <div class="tab-content">
-    <div class="tab-pane active" role="tabpanel" id="tree-tab" aria-labelledby="tree-tab-link">
-      <div class="container-fluid">
-        <div class="row">
-          <div id="viz-controls" class="col-2">
-            <div class="card">
-              <div class="card-header">Visualization Controls</div>
-              <div class="card-body">
-                <p class="card-text small">Right-click on the phylogenetic tree visualization to open context menu for more options to interact with tree.</p>
-                <p class="card-text small">CTRL+SHIFT+F to toggle fullscreen mode.</p>
-                <!-- Find leaves in tree -->
-                <div class="form-group">
-                  <label for="findLeavesInput">Find Leaves</label>
-                  <input type="text"
-                         id="findLeavesInput"
-                         class="form-control"
-                         placeholder="Enter leaf name(s)">
-                </div>
-                <!-- branchScaleInput: scale branch length -->
-                <div class="form-group">
-                  <label for="branchScaleInput">Tree Branch Scale</label>
-                  <input type="range"
-                         id="branchScaleInput"
-                         class="custom-range"
-                         min="0"
-                         max="1.0"
-                         value="0.5"
-                         step="0.05">
-                </div>
-                <!-- metadata block width -->
-                <div class="form-group">
-                  <label for="metadataBlockLengthInput">Metadata Block Width</label>
-                  <input type="number"
-                         id="metadataBlockLengthInput"
-                         class="form-control"
-                         min="0"
-                         value="20"
-                         step="1">
-                </div>
-                <!-- headerAngleRotation -->
-                <div class="form-group">
-                  <label for="headerAngleRotationInput">Metadata Header Angle</label>
-                  <input type="range"
-                         id="headerAngleRotationInput"
-                         class="custom-range"
-                         min="0"
-                         max="90"
-                         value="0"
-                         step="1">
-                </div>
-                <div class="custom-control custom-switch">
-                  <input type="checkbox"
-                         id="showMetadataLabelsInput"
-                         class="custom-control-input"
-                         checked
-                         value="true">
-                  <label class="custom-control-label" for="showMetadataLabelsInput">Show Metadata Labels</label>
-                </div>
-                <div class="custom-control custom-switch">
-                  <input type="checkbox"
-                         id="highlightLowSupportBranchesInput"
-                         class="custom-control-input"
-                         checked
-                         value="false">
-                  <label class="custom-control-label" for="highlightLowSupportBranchesInput">Highlight Low Support Branches</label>
-                </div>
-                <div class="form-group">
-                  <label for="lowSupportInput">Low Support Threshold</label>
-                  <input type="number"
-                         id="lowSupportInput"
-                         class="form-control"
-                         min="0"
-                         value="95"
-                         step="1">
-                </div>
-                <div class="form-group">
-                  <label for="field-select">Select Tree Metadata Fields</label>
-                  <select id="field-select" name="field-select" multiple="" style="width: 100%"></select>
-                </div>
+<nav id="nav">
+  <div class="nav nav-tabs" id="nav-tab" role="tablist">
+    <a class="nav-item nav-link active"
+       id="tree-tab-link"
+       href="#tree-tab"
+       data-toggle="tab"
+       role="tab"
+       aria-controls="tree-tab"
+       aria-selected="true">
+      Tree <span class="sr-only">(current)</span>
+    </a>
+    <a class="nav-item nav-link"
+       id="table-tab-link"
+       href="#table-tab"
+       data-toggle="tab"
+       role="tab"
+       aria-controls="table-tab"
+       aria-selected="true">
+      Table
+    </a>
+  </div>
+</nav>
+<div class="tab-content">
+  <div class="tab-pane active" role="tabpanel" id="tree-tab" aria-labelledby="tree-tab-link">
+    <div class="container-fluid">
+      <div class="row">
+        <div id="viz-controls" class="col-2">
+          <div class="card">
+            <div class="card-header">Visualization Controls</div>
+            <div class="card-body">
+              <p class="card-text small">Right-click on the phylogenetic tree visualization to open context menu for
+                more options to interact with tree.</p>
+              <p class="card-text small">CTRL+SHIFT+F to toggle fullscreen mode.</p>
+              <!-- Find leaves in tree -->
+              <div class="form-group">
+                <label for="findLeavesInput">Find Leaves</label>
+                <input type="text"
+                       id="findLeavesInput"
+                       class="form-control"
+                       placeholder="Enter leaf name(s)">
+              </div>
+              <!-- branchScaleInput: scale branch length -->
+              <div class="form-group">
+                <label for="branchScaleInput">Tree Branch Scale</label>
+                <input type="range"
+                       id="branchScaleInput"
+                       class="custom-range"
+                       min="0"
+                       max="1.0"
+                       value="0.5"
+                       step="0.05">
+              </div>
+              <!-- metadata block width -->
+              <div class="form-group">
+                <label for="metadataBlockLengthInput">Metadata Block Width</label>
+                <input type="number"
+                       id="metadataBlockLengthInput"
+                       class="form-control"
+                       min="0"
+                       value="20"
+                       step="1">
+              </div>
+              <!-- headerAngleRotation -->
+              <div class="form-group">
+                <label for="headerAngleRotationInput">Metadata Header Angle</label>
+                <input type="range"
+                       id="headerAngleRotationInput"
+                       class="custom-range"
+                       min="0"
+                       max="90"
+                       value="0"
+                       step="1">
+              </div>
+              <div class="custom-control custom-switch">
+                <input type="checkbox"
+                       id="showMetadataLabelsInput"
+                       class="custom-control-input"
+                       checked
+                       value="true">
+                <label class="custom-control-label" for="showMetadataLabelsInput">Show Metadata Labels</label>
+              </div>
+              <div class="custom-control custom-switch">
+                <input type="checkbox"
+                       id="highlightLowSupportBranchesInput"
+                       class="custom-control-input"
+                       checked
+                       value="false">
+                <label class="custom-control-label" for="highlightLowSupportBranchesInput">Highlight Low Support
+                  Branches</label>
+              </div>
+              <div class="form-group">
+                <label for="lowSupportInput">Low Support Threshold</label>
+                <input type="number"
+                       id="lowSupportInput"
+                       class="form-control"
+                       min="0"
+                       value="95"
+                       step="1">
+              </div>
+              <div class="form-group">
+                <label for="field-select">Select Tree Metadata Fields</label>
+                <select id="field-select" name="field-select" multiple="" style="width: 100%"></select>
               </div>
             </div>
           </div>
-          <div id="tree-container" class="col-10">
-            <div id="tree-plot" style="overflow: none;"></div>
-          </div>
+        </div>
+        <div id="tree-container" class="col-10">
+          <div id="tree-plot" style="overflow: none;"></div>
         </div>
       </div>
     </div>
-    <div class="tab-pane" id="table-tab" role="tabpanel" aria-labelledby="table-tab-link">
-      <div class="container-fluid">
-        <div class="ag-theme-balham" id="metadata-grid" style="height: 600px; width: 100%;"></div>
-      </div>
+  </div>
+  <div class="tab-pane" id="table-tab" role="tabpanel" aria-labelledby="table-tab-link">
+    <div class="container-fluid">
+      <div class="ag-theme-balham" id="metadata-grid" style="height: 600px; width: 100%;"></div>
     </div>
   </div>
-  <script type="text/javascript">
-    var newick_string = "{{ newick_string }}";
-  </script>
-  <script type="text/javascript">
-    var genomeMetadata = {{ metadata_json_string }};
-  </script>
-  <script type="text/javascript">
-    var variantData = {{ variant_data }};
-  </script>
+</div>
+<script type="text/javascript">
+  var newick_string = "{{ newick_string }}";
+</script>
+<script type="text/javascript">
+  var genomeMetadata = {
+  {
+    metadata_json_string
+  }
+  }
+  ;
+</script>
 {{ phylocanvas_metadata_plugin }}
-  <script type="application/javascript">
+<script type="application/javascript">
 
-    var DEFAULT_GRID_COL_OPTS = {
-      filter: true,
-      sortable: true,
-      resizable: true
-    };
-    var cols = Object.keys(Object.values(genomeMetadata)[0]);
+  var DEFAULT_GRID_COL_OPTS = {
+    filter: true,
+    sortable: true,
+    resizable: true
+  };
+  var grid;
+
+  function newElement(htmlString) {
+    const frag = document.createRange().createContextualFragment(htmlString);
+    return frag.firstChild;
+  }
+
+  function getRowData(genomeMetadata, genomes) {
+    if (genomes === null) {
+      genomes = Object.keys(genomeMetadata)
+    }
+    return genomes.map(function (x) {
+      var record = genomeMetadata[x]
+      return cols.reduce(function (acc, col) {
+        if (record.hasOwnProperty(col)) {
+          acc[col] = record[col];
+        }
+        return acc;
+      }, {genome: x});
+    });
+  }
+
+  if (!_.isEmpty(genomeMetadata)) {
+    const cols = Object.keys(Object.values(genomeMetadata)[0]);
     cols.unshift('genome');
-    var columnDefs = cols.map(function(x) {
+    const columnDefs = cols.map(function (x) {
       return Object.assign(JSON.parse(JSON.stringify(DEFAULT_GRID_COL_OPTS)), {
         headerName: _.capitalize(x).replace(/_+/g, " "),
         field: x,
       });
     });
 
-    var rowData = Object.keys(genomeMetadata).map(function(x) {
+    const rowData = Object.keys(genomeMetadata).map(function (x) {
       var record = genomeMetadata[x]
-      return cols.reduce(function(acc, col) {
+      return cols.reduce(function (acc, col) {
         if (record.hasOwnProperty(col)) {
           acc[col] = record[col];
         }
@@ -330,139 +411,119 @@
       }, {genome: x});
     });
 
-    function getRowData(genomeMetadata, genomes) {
-      if (genomes === null) {
-        genomes = Object.keys(genomeMetadata)
-      }
-      return genomes.map(function(x) {
-        var record = genomeMetadata[x]
-        return cols.reduce(function(acc, col) {
-          if (record.hasOwnProperty(col)) {
-            acc[col] = record[col];
-          }
-          return acc;
-        }, {genome: x});
-      });
-    }
-
     // let the grid know which columns and what data to use
     var gridOptions = {
       columnDefs: columnDefs,
       rowData: rowData,
       rowSelection: 'multiple'
     };
+    grid = new agGrid.Grid(document.getElementById('metadata-grid'), gridOptions);
+  }
 
-    var $grid = document.getElementById('metadata-grid')
 
-    var grid = new agGrid.Grid($grid, gridOptions);
+  var $treePlot = document.getElementById('tree-plot');
 
-    function newElement(htmlString) {
-      var frag = document.createRange().createContextualFragment(htmlString);
-      return frag.firstChild;
+  var Phylocanvas = window.Phylocanvas;
+  Phylocanvas.default.plugin(metadataPlugin.default);
+  var tree = Phylocanvas.default.createTree('tree-plot', {
+    padding: 0,
+    metadata: {
+      padding: 5,
+      headerAngle: 0,
+      blockLength: 20,
+    },
+    history: false,
+    baseNodeSize: 0,
+  });
+
+  function updateHeight() {
+    var BOTTOM_PADDING = 20;
+    var top = $treePlot.getBoundingClientRect().top;
+    var height = window.innerHeight - top - BOTTOM_PADDING;
+    if (height < 300) {
+      height = 300;
     }
+    $treePlot.style.height = height + 'px';
+    tree.resizeToContainer();
+    setBranchScale(document.getElementById("branchScaleInput").value);
+  }
 
-    var $treePlot = document.getElementById('tree-plot');
+  window.addEventListener("resize", updateHeight);
 
-    var Phylocanvas = window.Phylocanvas;
-    Phylocanvas.default.plugin(metadataPlugin.default);
-    var tree = Phylocanvas.default.createTree('tree-plot', {
-      padding: 0,
-      metadata: {
-        padding: 5,
-        headerAngle: 0,
-        blockLength: 20,
-      },
-      history: false,
-      baseNodeSize: 0,
-    });
+  document.getElementById('metadataBlockLengthInput').addEventListener('change', function (e) {
+    tree.metadata.blockLength = Number(e.target.value);
+    tree.draw();
+  });
 
-    function updateHeight(){
-      var BOTTOM_PADDING = 20;
-      var top = $treePlot.getBoundingClientRect().top;
-      var height = window.innerHeight - top - BOTTOM_PADDING;
-      if (height < 300) {
-        height = 300;
-      }
-      $treePlot.style.height = height + 'px';
-      tree.resizeToContainer();
-      setBranchScale(document.getElementById("branchScaleInput").value);
+  document.getElementById('headerAngleRotationInput').addEventListener('change', function (e) {
+    tree.metadata.headerAngle = Number(e.target.value);
+    tree.draw();
+  });
+
+  function setBranchScale(value) {
+    tree.setBranchScale(value);
+    tree.currentBranchScale = value;
+    tree.fitInPanel();
+    tree.offsetx = 0;
+    tree.draw();
+  }
+
+  document.getElementById("branchScaleInput").addEventListener('change', function (e) {
+    var value = Number(e.target.value);
+    setBranchScale(value);
+  });
+
+  document.getElementById('showMetadataLabelsInput').addEventListener('change', function () {
+    tree.metadata.showLabels = !tree.metadata.showLabels;
+    var $input = document.getElementById('headerAngleRotationInput');
+    if (tree.metadata.showLabels) {
+      $input.value = tree.metadata.headerAngle = 0;
+    } else {
+      $input.value = tree.metadata.headerAngle = 45;
     }
-    window.addEventListener("resize", updateHeight);
+    tree.draw();
+  });
 
-    document.getElementById('metadataBlockLengthInput').addEventListener('change', function(e){
-      const value = Number(e.target.value);
-      tree.metadata.blockLength = value;
-      tree.draw();
-    });
-
-    document.getElementById('headerAngleRotationInput').addEventListener('change', function(e){
-      const value = Number(e.target.value);
-      tree.metadata.headerAngle = value;
-      tree.draw();
-    });
-
-    function setBranchScale(value) {
-      tree.setBranchScale(value);
-      tree.currentBranchScale = value;
-      tree.fitInPanel();
-      tree.offsetx = 0;
-      tree.draw();
-    }
-
-    document.getElementById("branchScaleInput").addEventListener('change', function(e){
-      var value = Number(e.target.value);
-      setBranchScale(value);
-    });
-
-    document.getElementById('showMetadataLabelsInput').addEventListener('change', function(){
-      tree.metadata.showLabels = !tree.metadata.showLabels;
-      var $input = document.getElementById('headerAngleRotationInput');
-      if (tree.metadata.showLabels) {
-        $input.value = tree.metadata.headerAngle = 0;
-      } else {
-        $input.value = tree.metadata.headerAngle = 45;
-      }
-      tree.draw();
-    });
-
-    document.getElementById('findLeavesInput').addEventListener('keyup', function(e) {
-      var element = e.target;
-      var value = e.target.value;
-      if (value === '') {
-        element.classList.remove('is-valid');
-        element.classList.remove('is-invalid');
-        return;
-      }
-      var regex;
-      try {
-        regex = RegExp('^' + value)
-      } catch {
-        return;
-      }
-      foundLeaves = tree.findLeaves(regex);
-      if (foundLeaves.length === 0) {
-        element.classList.add('is-invalid');
-        return;
-      }
+  document.getElementById('findLeavesInput').addEventListener('keyup', function (e) {
+    var element = e.target;
+    var value = e.target.value;
+    if (value === '') {
+      element.classList.remove('is-valid');
       element.classList.remove('is-invalid');
-      element.classList.add('is-valid');
-      tree.leaves.forEach(function(x) { x.selected = false; });
-      foundLeaves.forEach(function(x) {
-        x.selected = true;
-        x.highlighted = true;
-        setTimeout(function() {
-          x.highlighted = false;
-        }, 1000);
-      });
-      tree.fitInPanel(foundLeaves);
-      tree.draw();
-      sel_leaves = foundLeaves.reduce(function(acc, x) {
-        acc[x.id] = 1;
-        return acc;
-      }, {});
-      console.log('sel_leaves', sel_leaves)
-      console.log('grid', grid)
-      grid.context.beans.gridApi.beanInstance.forEachNode(function(x) {
+      return;
+    }
+    var regex;
+    try {
+      regex = RegExp('^' + value)
+    } catch {
+      return;
+    }
+    var foundLeaves = tree.findLeaves(regex);
+    if (foundLeaves.length === 0) {
+      element.classList.add('is-invalid');
+      return;
+    }
+    element.classList.remove('is-invalid');
+    element.classList.add('is-valid');
+    tree.leaves.forEach(function (x) {
+      x.selected = false;
+    });
+    foundLeaves.forEach(function (x) {
+      x.selected = true;
+      x.highlighted = true;
+      setTimeout(function () {
+        x.highlighted = false;
+      }, 1000);
+    });
+    tree.fitInPanel(foundLeaves);
+    tree.draw();
+    var sel_leaves = foundLeaves.reduce(function (acc, x) {
+      acc[x.id] = 1;
+      return acc;
+    }, {});
+    console.log('sel_leaves', sel_leaves)
+    if (!_.isUndefined(grid)) {
+      grid.context.beans.gridApi.beanInstance.forEachNode(function (x) {
         if (sel_leaves.hasOwnProperty(x.data.genome)) {
           console.log(x);
           x.selected = true;
@@ -471,202 +532,213 @@
         }
       });
       grid.context.beans.gridApi.beanInstance.redrawRows();
-    });
+    }
+  });
 
-    function highlightLowSupportBranches(supportThreshold, lowSupportColour) {
-      if (supportThreshold === undefined || supportThreshold === null) {
-        supportThreshold = 95; // 95%
-      }
-      if (lowSupportColour === undefined || lowSupportColour === null) {
-        lowSupportColour = '#f00'; // red
-      }
-      for (let nodeId in tree.branches) {
-        if (tree.branches.hasOwnProperty(nodeId)) {
-          let node = tree.branches[nodeId];
-          if (node.children.length === 0) {
-            continue;
-          }
-          let bs = parseInt(node.label);
-          if (bs < supportThreshold) {
-            node.colour = lowSupportColour;
-          } else {
-            node.colour = '#000'; // black
-          }
+  function highlightLowSupportBranches(supportThreshold, lowSupportColour) {
+    if (supportThreshold === undefined || supportThreshold === null) {
+      supportThreshold = 95; // 95%
+    }
+    if (lowSupportColour === undefined || lowSupportColour === null) {
+      lowSupportColour = '#f00'; // red
+    }
+    for (let nodeId in tree.branches) {
+      if (tree.branches.hasOwnProperty(nodeId)) {
+        let node = tree.branches[nodeId];
+        if (node.children.length === 0) {
+          continue;
+        }
+        let bs = parseInt(node.label);
+        if (bs < supportThreshold) {
+          node.colour = lowSupportColour;
+        } else {
+          node.colour = '#000'; // black
         }
       }
-      tree.draw()
     }
+    tree.draw()
+  }
 
-    var lowSupportInput = document.getElementById('lowSupportInput');
-    var highlightLowSupportBranchesInput = document.getElementById('highlightLowSupportBranchesInput');
+  var lowSupportInput = document.getElementById('lowSupportInput');
+  var highlightLowSupportBranchesInput = document.getElementById('highlightLowSupportBranchesInput');
 
-    lowSupportInput.addEventListener('change', function() {
-      if (highlightLowSupportBranchesInput.checked) {
-        highlightLowSupportBranches(parseInt(lowSupportInput.value))
-      }
-    })
+  lowSupportInput.addEventListener('change', function () {
+    if (highlightLowSupportBranchesInput.checked) {
+      highlightLowSupportBranches(parseInt(lowSupportInput.value))
+    }
+  })
 
-    highlightLowSupportBranchesInput.addEventListener('change', function(e) {
-      const element = e.target;
-      console.log('highlightLowSupportBranchesInput', element, e, element.value)
-      if (element.checked) {
-        highlightLowSupportBranches(parseInt(lowSupportInput.value))
-      } else {
-        highlightLowSupportBranches(Infinity, '#000')
-      }
-    });
+  highlightLowSupportBranchesInput.addEventListener('change', function (e) {
+    const element = e.target;
+    console.log('highlightLowSupportBranchesInput', element, e, element.value)
+    if (element.checked) {
+      highlightLowSupportBranches(parseInt(lowSupportInput.value))
+    } else {
+      highlightLowSupportBranches(Infinity, '#000')
+    }
+  });
 
-    tree.on('error', function(event){ throw event.error; });
+  tree.on('error', function (event) {
+    throw event.error;
+  });
 
-    function setTreeMetadata(tree, genomeMetadata, fields) {
-      var vals = Object.values(genomeMetadata);
-      var fieldValueCounts = vals.reduce(function(acc, mdRecord) {
-        Object.keys(mdRecord).reduce(function(acc2, fieldName) {
-          var mdVal = mdRecord[fieldName];
-          if (mdRecord[fieldName] !== null) {
-            if (acc2.hasOwnProperty(fieldName)) {
-              if (acc2[fieldName].hasOwnProperty(mdVal)) {
-                acc2[fieldName][mdVal] += 1;
-              } else {
-                acc2[fieldName][mdVal]=1;
-              }
+  function setTreeMetadata(tree, genomeMetadata, fields) {
+    var vals = Object.values(genomeMetadata);
+    var fieldValueCounts = vals.reduce(function (acc, mdRecord) {
+      Object.keys(mdRecord).reduce(function (acc2, fieldName) {
+        var mdVal = mdRecord[fieldName];
+        if (mdRecord[fieldName] !== null) {
+          if (acc2.hasOwnProperty(fieldName)) {
+            if (acc2[fieldName].hasOwnProperty(mdVal)) {
+              acc2[fieldName][mdVal] += 1;
             } else {
-              acc2[fieldName] = {};
-              acc2[fieldName][mdVal]=1;
+              acc2[fieldName][mdVal] = 1;
             }
-          };
-          return acc2;
-        }, acc);
-        return acc;
-      }, {});
+          } else {
+            acc2[fieldName] = {};
+            acc2[fieldName][mdVal] = 1;
+          }
+        }
+        ;
+        return acc2;
+      }, acc);
+      return acc;
+    }, {});
 
-      var fieldValueColour = Object.keys(fieldValueCounts).reduce(function(acc, fieldName) {
-        if (!acc.hasOwnProperty(fieldName)) {
-          acc[fieldName] = {};
-        };
-        var valueCounts = fieldValueCounts[fieldName];
-        var isAllNumbers = Object.keys(valueCounts).reduce(function(acc, x) {
-          return !Number.isNaN(Number(x)) && acc;
-        }, true);
-        var isAllDates = Object.keys(valueCounts).reduce(function(acc, x) {
-          return !Number.isNaN(Date.parse(x)) && acc;
-        }, true);
-        var sorted_keys;
-        var map_new_to_old = {};
+    var fieldValueColour = Object.keys(fieldValueCounts).reduce(function (acc, fieldName) {
+      if (!acc.hasOwnProperty(fieldName)) {
+        acc[fieldName] = {};
+      }
+      ;
+      var valueCounts = fieldValueCounts[fieldName];
+      var isAllNumbers = Object.keys(valueCounts).reduce(function (acc, x) {
+        return !Number.isNaN(Number(x)) && acc;
+      }, true);
+      var isAllDates = Object.keys(valueCounts).reduce(function (acc, x) {
+        return !Number.isNaN(Date.parse(x)) && acc;
+      }, true);
+      var sorted_keys;
+      var map_new_to_old = {};
+      if (isAllNumbers) {
+        sorted_keys = Object.keys(valueCounts).map(Number).sort(function (a, b) {
+          return a - b;
+        });
+      } else if (isAllDates) {
+        map_new_to_old = Object.keys(valueCounts).reduce(function (acc, d) {
+          acc[Date.parse(d)] = d;
+          return acc;
+        }, {});
+        sorted_keys = Object.keys(map_new_to_old).sort(function (a, b) {
+          return a - b;
+        });
+      } else {
+        sorted_keys = Object.keys(valueCounts).sort(function (a, b) {
+          return valueCounts[b] - valueCounts[a];
+        });
+      }
+      var n = sorted_keys.length;
+      var colours;
+      if (isAllNumbers || isAllDates) {
+        colours = chroma.scale('Blues').domain([sorted_keys[0], sorted_keys[n - 1]]);
+      } else {
+        if (n > 12) {
+          colours = chroma.scale('Spectral').colors(n);
+        } else if (n > 9) {
+          colours = chroma.brewer.Set3;
+        } else {
+          colours = chroma.brewer.Pastel1;
+        }
+      }
+      for (var i = 0; i < sorted_keys.length; i++) {
         if (isAllNumbers) {
-          sorted_keys = Object.keys(valueCounts).map(Number).sort(function (a,b) { return a - b; });
+          acc[fieldName][sorted_keys[i] + ""] = colours(sorted_keys[i]);
         } else if (isAllDates) {
-          map_new_to_old = Object.keys(valueCounts).reduce(function (acc, d) {
-              acc[Date.parse(d)] = d;
-              return acc;
-          }, {});
-          sorted_keys = Object.keys(map_new_to_old).sort(function (a,b) { return a - b; });
+          acc[fieldName][map_new_to_old[sorted_keys[i]]] = colours(sorted_keys[i]);
         } else {
-          sorted_keys = Object.keys(valueCounts).sort(function (a, b) {
-            return valueCounts[b] - valueCounts[a];
-          });
-        }
-        var n = sorted_keys.length;
-        var colours;
-        if (isAllNumbers || isAllDates) {
-          colours = chroma.scale('Blues').domain([sorted_keys[0], sorted_keys[n-1]]);
-        } else {
-          if (n > 12) {
-            colours = chroma.scale('Spectral').colors(n);
-          } else if (n > 9) {
-            colours = chroma.brewer.Set3;
-          } else {
-            colours = chroma.brewer.Pastel1;
-          }
-        }
-        for (var i = 0; i < sorted_keys.length; i++) {
-          if (isAllNumbers) {
-            acc[fieldName][sorted_keys[i]+""] = colours(sorted_keys[i]);
-          } else if (isAllDates) {
-            acc[fieldName][map_new_to_old[sorted_keys[i]]] = colours(sorted_keys[i]);
-          } else {
-            acc[fieldName][sorted_keys[i]] = colours[i];
-          }
-        }
-        return acc;
-      }, {});
-
-      for (var leaf of tree.leaves) {
-        leaf.data = null;
-      }
-
-
-      for (var leaf of tree.leaves) {
-        if (!leaf.data) leaf.data = {};
-        var gmd = genomeMetadata[leaf.id];
-        for (var colName of fields) {
-          var val = gmd[colName];
-          var isValNull = val === null;
-          leaf.data[colName] = {
-            label: isValNull ? "" : val + "",
-            colour:  isValNull ? '#FFF' : fieldValueColour[colName][val],
-          };
+          acc[fieldName][sorted_keys[i]] = colours[i];
         }
       }
+      return acc;
+    }, {});
+
+    for (var leaf of tree.leaves) {
+      leaf.data = null;
     }
 
-    tree.on('beforeFirstDraw', function() {
-      var fields = _.keys(_.first(_.values(genomeMetadata)));
-      setTreeMetadata(tree, genomeMetadata, fields);
-    });
 
-    tree.on('subtree', function(x){
-      setBranchScale(document.getElementById("branchScaleInput").value);
-      var subtreeNodes = tree.branches[x.node].tree.leaves.map((node) => node.id)
-      var newRowData = getRowData(genomeMetadata, subtreeNodes)
-      grid.context.beans.gridApi.beanInstance.setRowData(newRowData)
-    });
-
-    tree.setTreeType('rectangular');
-    tree.alignLabels = true;
-
-    tree.load(newick_string);
-    window.tree = tree;
-    updateHeight();
-    setBranchScale(0.5);
-
-    // Add event handler for ctrl+shift+f for toggling fullscreen view
-    window.is_fullscreen = false;
-    document.addEventListener('keyup', function (event) {
-      if (event.ctrlKey && event.key === 'F') {
-        nav = document.getElementById('nav');
-        vizControls = document.getElementById('viz-controls');
-        treeContainer = document.getElementById('tree-container');
-        window.is_fullscreen = !window.is_fullscreen;
-        if (window.is_fullscreen) {
-          nav.setAttribute('hidden', true);
-          vizControls.setAttribute('hidden', true);
-          treeContainer.classList.remove('col-10');
-          treeContainer.classList.add('col-12');
-        } else {
-          nav.removeAttribute('hidden');
-          vizControls.removeAttribute('hidden');
-          treeContainer.classList.remove('col-12');
-          treeContainer.classList.add('col-10');
-        }
-        updateHeight();
+    for (var leaf of tree.leaves) {
+      if (!leaf.data) leaf.data = {};
+      var gmd = genomeMetadata[leaf.id];
+      for (var colName of fields) {
+        var val = gmd[colName];
+        var isValNull = val === null;
+        leaf.data[colName] = {
+          label: isValNull ? "" : val + "",
+          colour: isValNull ? '#FFF' : fieldValueColour[colName][val],
+        };
       }
-    });
+    }
+  }
 
+  tree.on('beforeFirstDraw', function () {
     var fields = _.keys(_.first(_.values(genomeMetadata)));
+    setTreeMetadata(tree, genomeMetadata, fields);
+  });
 
-    document.getElementById("field-select").innerHTML = _.join(_.map(fields, function(x) {return "<option value=\"" + x + "\">" + x + "</option>"; }), "\n")
+  tree.on('subtree', function (x) {
+    setBranchScale(document.getElementById("branchScaleInput").value);
+    var subtreeNodes = tree.branches[x.node].tree.leaves.map((node) => node.id)
+    var newRowData = getRowData(genomeMetadata, subtreeNodes)
+    grid.context.beans.gridApi.beanInstance.setRowData(newRowData)
+  });
 
-    window.fields = fields;
-    $(document).ready(function(){
-      $("select#field-select").select2();
-      $("#field-select").on("change", function(e) {
-        var selectData = $("#field-select").select2("data");
-        var ids = _.map(selectData, "id");
-        setTreeMetadata(tree, genomeMetadata, ids);
-        tree.draw();
-      });
+  tree.setTreeType('rectangular');
+  tree.alignLabels = true;
+
+  tree.load(newick_string);
+  window.tree = tree;
+  updateHeight();
+  setBranchScale(0.5);
+
+  // Add event handler for ctrl+shift+f for toggling fullscreen view
+  window.is_fullscreen = false;
+  document.addEventListener('keyup', function (event) {
+    if (event.ctrlKey && event.key === 'F') {
+      nav = document.getElementById('nav');
+      vizControls = document.getElementById('viz-controls');
+      treeContainer = document.getElementById('tree-container');
+      window.is_fullscreen = !window.is_fullscreen;
+      if (window.is_fullscreen) {
+        nav.setAttribute('hidden', true);
+        vizControls.setAttribute('hidden', true);
+        treeContainer.classList.remove('col-10');
+        treeContainer.classList.add('col-12');
+      } else {
+        nav.removeAttribute('hidden');
+        vizControls.removeAttribute('hidden');
+        treeContainer.classList.remove('col-12');
+        treeContainer.classList.add('col-10');
+      }
+      updateHeight();
+    }
+  });
+
+  var fields = _.keys(_.first(_.values(genomeMetadata)));
+
+  document.getElementById("field-select").innerHTML = _.join(_.map(fields, function (x) {
+    return "<option value=\"" + x + "\">" + x + "</option>";
+  }), "\n")
+
+  window.fields = fields;
+  $(document).ready(function () {
+    $("select#field-select").select2();
+    $("#field-select").on("change", function (e) {
+      var selectData = $("#field-select").select2("data");
+      var ids = _.map(selectData, "id");
+      setTreeMetadata(tree, genomeMetadata, ids);
+      tree.draw();
     });
-  </script>
+  });
+</script>
 </body>
 </html>

--- a/shiptv/tmpl/phylocanvas.html
+++ b/shiptv/tmpl/phylocanvas.html
@@ -165,71 +165,19 @@
           object-fit: contain;
       }
   </style>
-  <style>{
-  {
-      bootstrap_css
-  }
-  }</style>
-  <script>{
-    {
-      jquery_js
-    }
-  }</script>
-  <script>{
-    {
-      popper_js
-    }
-  }</script>
-  <script>{
-    {
-      bootstrap_js
-    }
-  }</script>
-  <script>{
-    {
-      phylocanvas_js
-    }
-  }</script>
-  <script>{
-    {
-      polyfill_js
-    }
-  }</script>
-  <script>{
-    {
-      chroma_js
-    }
-  }</script>
-  <script>{
-    {
-      lodash_js
-    }
-  }</script>
-  <script>{
-    {
-      ag_grid_js
-    }
-  }</script>
-  <style>{
-  {
-      ag_grid_css
-  }
-  }</style>
-  <style>{
-  {
-      ag_grid_theme_css
-  }
-  }</style>
-  <style>{
-  {
-      select2_css
-  }
-  }</style>
-  <script>{
-    {
-      select2_js
-    }
-  }</script>
+  <style>{{ bootstrap_css }}</style>
+  <script>{{ jquery_js }}</script>
+  <script>{{ popper_js }}</script>
+  <script>{{ bootstrap_js }}</script>
+  <script>{{ phylocanvas_js }}</script>
+  <script>{{ polyfill_js }}</script>
+  <script>{{ chroma_js }}</script>
+  <script>{{ lodash_js }}</script>
+  <script>{{ ag_grid_js }}</script>
+  <style>{{ ag_grid_css }}</style>
+  <style>{{ ag_grid_theme_css }}</style>
+  <style>{{ select2_css }}</style>
+  <script>{{ select2_js }}</script>
 </head>
 <body>
 <nav id="nav">
@@ -354,12 +302,7 @@
   var newick_string = "{{ newick_string }}";
 </script>
 <script type="text/javascript">
-  var genomeMetadata = {
-  {
-    metadata_json_string
-  }
-  }
-  ;
+  var genomeMetadata = {{ metadata_json_string }};
 </script>
 {{ phylocanvas_metadata_plugin }}
 <script type="application/javascript">

--- a/tests/test_shiptv.py
+++ b/tests/test_shiptv.py
@@ -44,7 +44,7 @@ def test_command_line_interface():
                                           '-n', str(input_newick.absolute()),
                                           '-N', out_newick,
                                           '-o', out_html,
-                                          '-m', out_table])
+                                          '-M', out_table])
         assert test_result.exit_code == 0
         assert exists(out_html)
         assert exists(out_table)
@@ -61,7 +61,7 @@ def test_command_line_interface():
         test_result = runner.invoke(app, ['-r', str(input_ref_genbank.absolute()),
                                           '-n', str(input_newick.absolute()),
                                           '-o', out_html,
-                                          '-m', out_table,
+                                          '-M', out_table,
                                           '-C', 95])
         assert test_result.exit_code == 0
         assert exists(out_html)


### PR DESCRIPTION
Changes: 

- ensure tree rendered even if `genomeMetadata` object is empty in `phylocanvas.html`
- add `--version` option to print shiptv version and exit
- add epilog to help with version info
- add example usage to help
- change `--metadata` short opt to `-m` from `-M`
- change `--output-metadata-table` short opt from `-m` to `-M`
- update lodash JS library to version 4.17.15